### PR TITLE
Fixed lowercase filename issues

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -176,7 +176,7 @@ function writecomponent(filename, comp)
     end
     str = str*string(comp.Mr)
     
-    filename = lowercase(filename)   
+    filename = endswith(filename, ".comp") ? filename : filename * ".comp"   
     open(filename, "w") do io
         write(io, str)
     end

--- a/src/components.jl
+++ b/src/components.jl
@@ -233,7 +233,7 @@ function readcomponentlist!(fs, foldername, filenames)
     
     for fn in filenames
         fname = fn * ".comp"
-        if lowercase(fname) in available
+        if fname in available
             fs.comps[fn] = readcomponent(joinpath(foldername, fname))
             count += 1
         else


### PR DESCRIPTION
First off, what a cool toolkit! I've noticed a few minor issues, which I'll try to fix where possible.

This one is about an inconsitency in the usage of lowercase filenames. Essentially it does away with all automatic lowercasing, which I think makes everything more consistent.

It should be noted that the filename (actually the suffix) appears to determine the component name, so perhaps this should not be also recorded inside the .comp file itself. (This may cause further inconsistencies or unexpected behavior.)